### PR TITLE
made 4 fixes as outlined

### DIFF
--- a/contracts/ImpossibleFactory.sol
+++ b/contracts/ImpossibleFactory.sol
@@ -25,7 +25,7 @@ contract ImpossibleFactory is IImpossibleFactory {
     }
 
     function setRouter(address _router) external {
-        //require(msg.sender == address(governance), "IF: FORBIDDEN");
+        require(msg.sender == address(governance), "IF: FORBIDDEN");
         require(router == address(0x0), 'IF: ROUTER_SET');
         router = _router;
     }
@@ -33,6 +33,11 @@ contract ImpossibleFactory is IImpossibleFactory {
     function changeTokenAccess(address token, bool allowed) external {
         require(msg.sender == address(governance), 'IF: FORBIDDEN');
         approvedTokens[token] = allowed;
+    }
+
+    function setWhitelist(bool b) external {
+        require(msg.sender == address(governance), "IF: FORBIDDEN");
+        whitelist = b;
     }
 
     function createPair(address tokenA, address tokenB) external override returns (address pair) {

--- a/contracts/ImpossibleRouter02.sol
+++ b/contracts/ImpossibleRouter02.sol
@@ -280,7 +280,7 @@ contract ImpossibleRouter02 is IImpossibleRouter02, ReentrancyGuard {
             (uint256 amount0Out, uint256 amount1Out) =
                 input == token0 ? (uint256(0), amountOut) : (amountOut, uint256(0));
             address to = i < path.length - 2 ? ImpossibleLibrary.pairFor(factory, output, path[i + 2]) : _to;
-            IImpossiblePair(ImpossibleLibrary.pairFor(factory, input, output)).cheapSwap(
+            IImpossiblePair(ImpossibleLibrary.pairFor(factory, input, output)).swap(
                 amount0Out,
                 amount1Out,
                 to,
@@ -412,7 +412,7 @@ contract ImpossibleRouter02 is IImpossibleRouter02, ReentrancyGuard {
             (uint256 amount0Out, uint256 amount1Out) =
                 ImpossibleLibrary.getAmountOutFeeOnTransfer(input, output, factory);
             address to = i < path.length - 2 ? ImpossibleLibrary.pairFor(factory, output, path[i + 2]) : _to;
-            IImpossiblePair(ImpossibleLibrary.pairFor(factory, input, output)).cheapSwap(
+            IImpossiblePair(ImpossibleLibrary.pairFor(factory, input, output)).swap(
                 amount0Out,
                 amount1Out,
                 to,

--- a/contracts/interfaces/IImpossiblePair.sol
+++ b/contracts/interfaces/IImpossiblePair.sol
@@ -53,13 +53,6 @@ interface IImpossiblePair is IImpossibleERC20 {
         bytes calldata
     ) external;
 
-    function cheapSwap(
-        uint256,
-        uint256,
-        address,
-        bytes calldata
-    ) external;
-
     function skim(address to) external;
 
     function sync() external;

--- a/contracts/libraries/ImpossibleLibrary.sol
+++ b/contracts/libraries/ImpossibleLibrary.sol
@@ -34,8 +34,7 @@ library ImpossibleLibrary {
                         hex'ff',
                         factory,
                         keccak256(abi.encodePacked(token0, token1)),
-                        hex'22e5caa20726e4a500ca018413833e41036a5671975cd98836af552fbc7a1774' // init code hash
-                        // de353d433fa966b87b4bc7c1e4c8035e23fd1ae8b9908cc103a0403d4abfbe13 in prod
+                        hex'd7b4238ea5ee3437860258ae45580ad156673c8f7448c1b761816caeac3178d5' // init code hash
                     )
                 )
             )
@@ -181,7 +180,7 @@ library ImpossibleLibrary {
                     // Don't need to check in other case for reserveOut > reserveOut.sub(x) >= sqrtK since that case doesnt cross midpt
                     if (reserveOut > sqrtK && boost0 != boost1) {
                         // Break into 2 trades => start point -> midpoint (sqrtK, sqrtK), then midpoint -> final point
-                        amountIn = sqrtK.sub(reserveIn).mul(10000).div(10000 - fee);
+                        amountIn = sqrtK.sub(reserveIn).mul(10000); // Still need to divide by (10000 - fee). Do with below calculation to prevent early truncation
                         amountOut = amountOut.sub(reserveOut.sub(sqrtK));
                         reserveOut = sqrtK;
                         reserveIn = sqrtK;
@@ -190,8 +189,8 @@ library ImpossibleLibrary {
             }
         }
         uint256 numerator = (reserveIn.add(artiLiqTerm)).mul(amountOut).mul(10000);
-        uint256 denominator = (reserveOut.add(artiLiqTerm)).sub(amountOut).mul(10000 - fee);
-        amountIn = amountIn.add((numerator / denominator).add(1));
+        uint256 denominator = (reserveOut.add(artiLiqTerm)).sub(amountOut);
+        amountIn = (amountIn.add((numerator / denominator)).div(10000 - fee)).add(1);
     }
 
     function getAmountOutFeeOnTransfer(

--- a/test/ImpossibleFactory.spec.ts
+++ b/test/ImpossibleFactory.spec.ts
@@ -68,7 +68,7 @@ describe('ImpossibleSwapFactory', () => {
   it('createPair:gas', async () => {
     const tx = await factory.createPair(...TEST_ADDRESSES)
     const receipt = await tx.wait()
-    expect(receipt.gasUsed).to.eq(3949954) // Uni v2 was 3051505. NOTE: this gas is a within-1% approx since we comment/change variables for pair tests.
+    expect(receipt.gasUsed).to.eq(4004557) // Uni v2 was 3051505. NOTE: this gas is a within-1% approx since we comment/change variables for pair tests.
   })
 
   it('setFeeTo', async () => {

--- a/test/ImpossiblePair.spec.ts
+++ b/test/ImpossiblePair.spec.ts
@@ -269,7 +269,7 @@ describe('ImpossiblePair', () => {
     await mineBlock(provider, (await provider.getBlock('latest')).timestamp + 1)
     const tx = await pair.swap(swapAmount, 0, wallet.address, '0x', overrides)
     const receipt = await tx.wait()
-    expect(receipt.gasUsed).to.eq(64394) // v2 uni was 73462
+    expect(receipt.gasUsed).to.eq(65199) // v2 uni was 73462
   })
 
   // Modified test to swap 1:1 token, just to check gas prices of swap
@@ -289,7 +289,7 @@ describe('ImpossiblePair', () => {
     await mineBlock(provider, (await provider.getBlock('latest')).timestamp + 1)
     const tx = await pair.swap(swapAmount, 0, wallet.address, '0x', overrides) // Testing gas fee
     const receipt = await tx.wait()
-    expect(receipt.gasUsed).to.eq(87702)
+    expect(receipt.gasUsed).to.eq(88507)
   })
 
   interface linInterpolateTestCase {

--- a/test/ImpossibleRouter01.spec.ts
+++ b/test/ImpossibleRouter01.spec.ts
@@ -355,8 +355,8 @@ describe('ImpossibleRouter01', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.ImpossibleRouter01]: 97095, // Uni was 101876
-              [RouterVersion.ImpossibleRouter02]: 96147
+              [RouterVersion.ImpossibleRouter01]: 99937, // Uni was 101876
+              [RouterVersion.ImpossibleRouter02]: 99937
             }[routerVersion as RouterVersion]
           )
         })
@@ -418,8 +418,8 @@ describe('ImpossibleRouter01', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.ImpossibleRouter01]: 111621, // Uni was 101876
-              [RouterVersion.ImpossibleRouter02]: 110673
+              [RouterVersion.ImpossibleRouter01]: 137451, // Uni was 101876
+              [RouterVersion.ImpossibleRouter02]: 137451
             }[routerVersion as RouterVersion]
           )
         })
@@ -481,8 +481,8 @@ describe('ImpossibleRouter01', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.ImpossibleRouter01]: 112001, // Uni was 101876
-              [RouterVersion.ImpossibleRouter02]: 111053
+              [RouterVersion.ImpossibleRouter01]: 137831, // Uni was 101876
+              [RouterVersion.ImpossibleRouter02]: 137831
             }[routerVersion as RouterVersion]
           )
         })
@@ -544,8 +544,8 @@ describe('ImpossibleRouter01', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.ImpossibleRouter01]: 112013, // Uni was 101876
-              [RouterVersion.ImpossibleRouter02]: 111065
+              [RouterVersion.ImpossibleRouter01]: 137843, // Uni was 101876
+              [RouterVersion.ImpossibleRouter02]: 137843
             }[routerVersion as RouterVersion]
           )
         })
@@ -607,8 +607,8 @@ describe('ImpossibleRouter01', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.ImpossibleRouter01]: 112340, // Uni was 101876
-              [RouterVersion.ImpossibleRouter02]: 111392
+              [RouterVersion.ImpossibleRouter01]: 138933, // Uni was 101876
+              [RouterVersion.ImpossibleRouter02]: 138933
             }[routerVersion as RouterVersion]
           )
         })
@@ -664,8 +664,8 @@ describe('ImpossibleRouter01', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.ImpossibleRouter01]: 101200, // Uni was 101876
-              [RouterVersion.ImpossibleRouter02]: 100230
+              [RouterVersion.ImpossibleRouter01]: 104098, // Uni was 101876
+              [RouterVersion.ImpossibleRouter02]: 104098
             }[routerVersion as RouterVersion]
           )
         })
@@ -727,8 +727,8 @@ describe('ImpossibleRouter01', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.ImpossibleRouter01]: 111803, // Uni was 101876
-              [RouterVersion.ImpossibleRouter02]: 110833
+              [RouterVersion.ImpossibleRouter01]: 137689, // Uni was 101876
+              [RouterVersion.ImpossibleRouter02]: 137689
             }[routerVersion as RouterVersion]
           )
         })
@@ -737,7 +737,7 @@ describe('ImpossibleRouter01', () => {
       describe('xybk swapTokensForExactTokens, double boost, case 1', () => {
         const token0Amount = bigNumberify('98000000000000000000')
         const token1Amount = bigNumberify('100000000000000000000')
-        const expectedSwapAmount = bigNumberify('9999999999999999999') // Off by 1 gwei
+        const expectedSwapAmount = bigNumberify('10000000000000000000')
         const outputAmount = bigNumberify('9941982512178805534')
 
         beforeEach(async () => {
@@ -791,8 +791,8 @@ describe('ImpossibleRouter01', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.ImpossibleRouter01]: 112402, // Uni was 101876
-              [RouterVersion.ImpossibleRouter02]: 111432
+              [RouterVersion.ImpossibleRouter01]: 138069, // Uni was 101876
+              [RouterVersion.ImpossibleRouter02]: 138069
             }[routerVersion as RouterVersion]
           )
         })
@@ -801,7 +801,7 @@ describe('ImpossibleRouter01', () => {
       describe('xybk swapTokensForExactTokens, double boost, case 2', () => {
         const token0Amount = bigNumberify('102324241243449991944')
         const token1Amount = bigNumberify('124882484835838434422')
-        const expectedSwapAmount = bigNumberify('49999999999999999999') // Off by 1 gwei
+        const expectedSwapAmount = bigNumberify('50000000000000000000') // Off by 1 gwei
         const outputAmount = bigNumberify('49488329728372278747')
 
         beforeEach(async () => {
@@ -855,8 +855,8 @@ describe('ImpossibleRouter01', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.ImpossibleRouter01]: 112414, // Uni was 101876
-              [RouterVersion.ImpossibleRouter02]: 111444
+              [RouterVersion.ImpossibleRouter01]: 138081, // Uni was 101876
+              [RouterVersion.ImpossibleRouter02]: 138081
             }[routerVersion as RouterVersion]
           )
         })
@@ -919,8 +919,8 @@ describe('ImpossibleRouter01', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.ImpossibleRouter01]: 112741, // Uni was 101876
-              [RouterVersion.ImpossibleRouter02]: 111771
+              [RouterVersion.ImpossibleRouter01]: 139171, // Uni was 101876
+              [RouterVersion.ImpossibleRouter02]: 139171
             }[routerVersion as RouterVersion]
           )
         })
@@ -1000,8 +1000,8 @@ describe('ImpossibleRouter01', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.ImpossibleRouter01]: 104014, // Uni was 138770
-              [RouterVersion.ImpossibleRouter02]: 103223
+              [RouterVersion.ImpossibleRouter01]: 107013, // Uni was 138770
+              [RouterVersion.ImpossibleRouter02]: 107013
             }[routerVersion as RouterVersion]
           )
         })
@@ -1076,8 +1076,8 @@ describe('ImpossibleRouter01', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.ImpossibleRouter01]: 119048, // Uni was 101876
-              [RouterVersion.ImpossibleRouter02]: 118251
+              [RouterVersion.ImpossibleRouter01]: 122119, // Uni was 101876
+              [RouterVersion.ImpossibleRouter02]: 122119
             }[routerVersion as RouterVersion]
           )
         })
@@ -1152,8 +1152,8 @@ describe('ImpossibleRouter01', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.ImpossibleRouter01]: 114944, // Uni was 101876
-              [RouterVersion.ImpossibleRouter02]: 114169
+              [RouterVersion.ImpossibleRouter01]: 117959, // Uni was 101876
+              [RouterVersion.ImpossibleRouter02]: 117959
             }[routerVersion as RouterVersion]
           )
         })
@@ -1230,8 +1230,8 @@ describe('ImpossibleRouter01', () => {
           const receipt = await tx.wait()
           expect(receipt.gasUsed).to.eq(
             {
-              [RouterVersion.ImpossibleRouter01]: 107902, // Uni was 101876
-              [RouterVersion.ImpossibleRouter02]: 107111
+              [RouterVersion.ImpossibleRouter01]: 110980, // Uni was 101876
+              [RouterVersion.ImpossibleRouter02]: 110980
             }[routerVersion as RouterVersion]
           )
         })

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -37,6 +37,7 @@ export async function pairFixture(provider: Web3Provider, [wallet]: Wallet[]): P
   const tokenA = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
   const tokenB = await deployContract(wallet, ERC20, [expandTo18Decimals(10000)], overrides)
 
+  await factory.setRouter(wallet.address)
   await factory.createPair(tokenA.address, tokenB.address, overrides)
   const pairAddress = await factory.getPair(tokenA.address, tokenB.address)
   const pair = new Contract(pairAddress, JSON.stringify(ImpossiblePair.abi), provider).connect(wallet)


### PR DESCRIPTION
1. Made 4 fixes as promised: adding whitelist, adding onlyIFRouter modifier to swap() at pair level, x*y=k check for all swaps at pair level and a global pause for tokens
2. Improved testing setup (able to uncomment some require checks)
3. Improved logic for getAmountsIn for xybk double boosted setups. Previous setup did division of amounts separately and that truncation sometimes caused a 1 wei difference between router check and pair check. Changed logic to perform division after augent/addend are summed instead